### PR TITLE
子コメントの投稿機能を追加

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -15,6 +15,7 @@ class CommentController extends Controller
         $post->comments()->create([
             'user_id' => Auth::user()->id,
             'content' => $request->content,
+            'parent_comment_id' => $request->parent_comment_id,
         ]);
         
         return back();

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -12,6 +12,7 @@ class Comment extends Model
     protected $fillable = [
         'user_id',
         'content',
+        'parent_comment_id',
     ];
     
     public function user()

--- a/public/js/reply.js
+++ b/public/js/reply.js
@@ -1,0 +1,41 @@
+// /sns/public/js/reply.js
+
+window.onload = function() {
+    // キャンセルボタンの要素を取得
+    var cancelReplyButton = document.querySelector('#cancelReply');
+
+    // キャンセルボタンがクリックされたときの処理を追加
+    cancelReplyButton.addEventListener('click', function(event) {
+        // フォームの送信を防ぐ
+        event.preventDefault();
+
+        // 親コメントのIDをクリア
+        var form = document.querySelector('.post_comment');
+        form.querySelector('#parentCommentIdField').value = '';
+
+        // フォームを元の位置に戻す
+        document.querySelector('#originalFormLocation').append(form);
+
+        // キャンセルボタンを非表示
+        cancelReplyButton.style.display = 'none';
+    });
+
+    document.querySelectorAll('.reply-button').forEach(function (button) {
+        button.addEventListener('click', function () {
+            // 親コメントのIDを取得
+            var commentId = this.dataset.commentId;
+
+            // 既存のフォームを取得
+            var form = document.querySelector('.post_comment');
+
+            // 隠しフィールドに親コメントのIDを設定
+            form.querySelector('#parentCommentIdField').value = commentId;
+
+            // フォームを親コメントの直後に挿入
+            document.querySelector(`#comment-${commentId}`).after(form);
+
+            // キャンセルボタンを表示
+            cancelReplyButton.style.display = 'block';
+        });
+    });
+}

--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -1,12 +1,14 @@
-<!-- comments.blade.php -->
-
-<div style="margin-left: {{ $margin }}px;">
+<div id="comment-{{ $comment->id }}" style="margin-left: {{ $margin }}px;">
     <img src="{{ $comment->user->user_image }}" alt="User image">
     <strong>{{ $comment->user->name }}</strong>
     <p>{{ $comment->content }}</p>
     <small>{{ $comment->created_at->format('Y-m-d H:i') }}</small>
-
+    
+    <!-- 返信ボタンの追加 -->
+    <button class="reply-button" data-comment-id="{{ $comment->id }}">返信</button>
+    
     @foreach($comment->children as $childComment)
         @include('comments', ['comment' => $childComment, 'margin' => $margin + 40])
     @endforeach
 </div>
+<script src="{{ asset('js/reply.js') }}"></script>  <!-- パスの変更 -->

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -43,13 +43,15 @@
         @include('comments', ['comment' => $comment, 'margin' => 0])
     @endforeach
     </div>
-    <div class='post_comment'>
+    <div id='originalFormLocation'>
         <img src="{{ Auth::user()->user_image }}" alt="User image">
-        <form method='POST' action='{{route('comment',$post)}}'>
+        <form class='post_comment' method='POST' action='{{route('comment',$post)}}'>
             @csrf
             <textarea name='content' placeholder='コメントを入力...'>{{old('content')}}</textarea>
+            <input type="hidden" name="parent_comment_id" id="parentCommentIdField" value="">  
             <p class='content_error' style='color:red'>{{$errors->first('content')}}</p>
             <button type='submit'>送信</button>
+            <button id='cancelReply' style='display: none;'>返信をやめる</button>
         </form>
     </div>
 </x-app-layout>


### PR DESCRIPTION
コメントへの返信(子コメントの作成)機能を追加
・各返信ボタンを押すとそのコメントの下に投稿フォームが移動する
・投稿フォームの位置を戻すための「返信をやめる」ボタンも追加