### PR TITLE
画像ファイルタイプのバリデーションを追加

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -18,7 +18,7 @@ class PostRequest extends FormRequest
             'post.category_id'=>'required|integer|exists:categories,id',
             'post.title'=>'required|string|max:50',
             'post.body'=>'required|string|max:2000',
-            'image'=>'required',
+            'image' => 'required|mimes:jpg,jpeg,png,gif,svg,webp',
         ];
     }
 }

--- a/resources/views/posts/create_post.blade.php
+++ b/resources/views/posts/create_post.blade.php
@@ -8,7 +8,7 @@
         @csrf
         <input type="hidden" name="post[category_id]" value="{{ $category->id }}" />
         <div class='image'>
-            <input id='file-input' type='file' name='image'>
+            <input id='file-input' type='file' name='image' accept='image/*'>
             <button type='button' id='reset-file'>Reset File</button>
         </div>
         <div class='title'>


### PR DESCRIPTION
・アップロード可能ファイル形式をjpg,jpeg,png,gif,svg,webpに限定
・画像ファイルのみ選択できるようhtmlを変更