### PR TITLE
commentsテーブルの外部キー制約の変更

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -47,6 +47,8 @@ class ProfileController extends Controller
         ]);
 
         $user = $request->user();
+        
+        $user->comments()->delete();
 
         Auth::logout();
 

--- a/database/migrations/2023_08_23_125723_modify_comments_foreign_key.php
+++ b/database/migrations/2023_08_23_125723_modify_comments_foreign_key.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropForeign('comments_user_id_foreign');
+            
+            $table->unsignedBigInteger('user_id')->nullable()->change();
+            
+            $table->foreign('user_id','comments_user_id_foreign')
+                ->references('id')->on('users')
+                ->onDelete('SET NULL');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -1,7 +1,11 @@
 @if($comment->trashed())
     <div class="w-2/3 h-24 bg-gray-300 shadow-lg rounded my-8 p-4 flex items-stretch" style="margin-left: {{ $margin ?? 0 }}px;">
         <div class="flex w-1/2 h-full items-center">
+            @if(is_null($comment->user_id))
+            <p>ユーザーが退会しました。</p>
+            @else
             <p>このコメントは削除されました。</p>
+            @endif
         </div>
         <div class="flex w-1/2 h-full items-end flex-row-reverse">
             <small>{{ $comment->created_at->format('Y-m-d H:i') }}</small>


### PR DESCRIPTION
ユーザー退会時に関連するcommentsテーブルのレコードを論理削除
commentsテーブルの外部キー制約を、null許容、参照先のuser削除時にnullに設定するように変更