### PR TITLE
user削除時の参照元レコードの物理削除

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -48,8 +48,22 @@ class ProfileController extends Controller
 
         $user = $request->user();
         
+        //各参照先のカラムを物理削除
+        $categories=$user->categories;
+        foreach($categories as $category){
+            foreach($category->posts as $post){
+                $post->likes()->forceDelete();
+                $post->comments()->forceDelete();
+            }
+            $category->posts()->forceDelete();
+            $category->relationships()->forceDelete();
+        }
+        $user->categories()->forceDelete();
+        $user->relationships()->forceDelete();
+        $user->likes()->forceDelete();
+        
         $user->comments()->delete();
-
+        
         Auth::logout();
 
         $user->delete();

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -24,6 +24,7 @@ class Category extends Model
             foreach ($category->posts as $post) {
                 $post->delete();
             }
+            $category->relationships()->delete();
         });
     }
     

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -48,6 +48,7 @@ class Post extends Model
     {
         static::deleted(function ($post){
             $post->comments()->delete();
+            $post->likes()->delete();
         });
     }
     


### PR DESCRIPTION
user削除時の外部キー制約によるエラー回避のため、user削除直前に関連する各レコードを物理削除

softDeletesが設定されるテーブルもあるため、区別するためにProfileController内で愚直に物理削除を行ったが、更にいい書き方があれば変更したい