### PR TITLE
tagsテーブルのmigrationファイル追加

### DIFF
--- a/database/migrations/2023_09_11_215759_create_tags_table.php
+++ b/database/migrations/2023_09_11_215759_create_tags_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+            $table->integer('position');
+            $table->timestamps();
+            
+            $table->unique(['category_id', 'position']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2023_09_11_220423_add_tag_id_to_posts_table.php
+++ b/database/migrations/2023_09_11_220423_add_tag_id_to_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->foreignId('tag_id')
+            ->nullable()
+            ->after('category_id')
+            ->constrained()
+            ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            
+        });
+    }
+};


### PR DESCRIPTION
各カテゴリに紐づき、カテゴリ内の投稿に対して0~1個付与できるtagの機能追加を行っていく。
今回はそのtagテーブルを新規作成するmigrationファイルと、参照元のpostsテーブルにtag_idを追加するmigrationファイルを作成